### PR TITLE
chore: add pubspec.yaml to root for github actions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,5 @@
+name: 'two_fer'
+environment:
+  sdk: '>=3.2.0 <4.0.0'
+dev_dependencies:
+  test: '<2.0.0'


### PR DESCRIPTION
This pull request adds a new `pubspec.yaml` file to the project, setting up basic Dart project configuration and test dependencies. This is a standard initial setup for a Dart package.

- Project setup:
  * Added `pubspec.yaml` file specifying the project name (`two_fer`), Dart SDK version constraints, and a test dependency.